### PR TITLE
remove "dist:trusty" line from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 {
   "os": "linux",
-  "dist": "trusty",
   "sudo": false,
   "cache": "packages",
   "group": "stable",


### PR DESCRIPTION
Fixed failing travis build.