### PR TITLE
fix: overlapping first and last points in circle layout

### DIFF
--- a/R/helper_funcs.R
+++ b/R/helper_funcs.R
@@ -28,7 +28,9 @@ calc_coordinates <- function(N, M, limits, segment = 0.5) {
       # theta_right is the right-hand end of the arc
       theta_right <- pi - theta_narrow
       theta <- seq( theta_left, theta_right,
-                   len = counts[i])
+                   len = counts[i]+ (segment == 1))
+      # generate one extra point then drop last when full circle
+      if (segment == 1) theta <- head(theta, -1) 
       # subtract the seats already plotted from N
       # N becomes 'seats left to calculate'
       N <<- N - counts[i]


### PR DESCRIPTION
``` r
library(ggplot2)
library(ggparliament)

# single row circle with n seats
test_circle <- function(n) {
  data <- data.frame(party = "party", seats = n)
  
  data_circle <- parliament_data(
    election_data = data,
    type         = "circle",
    parl_rows    = 1,
    party_seats  = data$seats
  )
  
  ggplot(data_circle, aes(x = x, y = y, colour = party)) +
    geom_parliament_seats()
}

# shows 3 seats, should be 4
test_circle(4)
```

![](https://i.imgur.com/ILhQuXj.png)<!-- -->

<sup>Created on 2025-12-03 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>


this patch fixes this issue by creating an extra point and removing it again when creating a circle layout parliament plot